### PR TITLE
use reflection to check if method enableHostnameVerification exists

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.ibm.cloud</groupId>
     <artifactId>cfenv-processor-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.14</version>
+    <version>0.0.15-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -164,7 +164,7 @@
         <connection>scm:git:git@github.com:IBM/ibmcloud-cfenv-processors.git</connection>
         <developerConnection>scm:git:git@github.com:IBM/ibmcloud-cfenv-processors.git</developerConnection>
         <url>https://github.com/IBM/ibmcloud-cfenv-processors</url>
-      <tag>cfenv-processor-parent-0.0.14</tag>
+      <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.ibm.cloud</groupId>
     <artifactId>cfenv-processor-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.14-SNAPSHOT</version>
+    <version>0.0.14</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -164,7 +164,7 @@
         <connection>scm:git:git@github.com:IBM/ibmcloud-cfenv-processors.git</connection>
         <developerConnection>scm:git:git@github.com:IBM/ibmcloud-cfenv-processors.git</developerConnection>
         <url>https://github.com/IBM/ibmcloud-cfenv-processors</url>
-      <tag>HEAD</tag>
+      <tag>cfenv-processor-parent-0.0.14</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.ibm.cloud</groupId>
     <artifactId>cfenv-processor-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.13</version>
+    <version>0.0.14-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -164,7 +164,7 @@
         <connection>scm:git:git@github.com:IBM/ibmcloud-cfenv-processors.git</connection>
         <developerConnection>scm:git:git@github.com:IBM/ibmcloud-cfenv-processors.git</developerConnection>
         <url>https://github.com/IBM/ibmcloud-cfenv-processors</url>
-      <tag>cfenv-processor-parent-0.0.13</tag>
+      <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.ibm.cloud</groupId>
     <artifactId>cfenv-processor-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.13-SNAPSHOT</version>
+    <version>0.0.13</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -164,7 +164,7 @@
         <connection>scm:git:git@github.com:IBM/ibmcloud-cfenv-processors.git</connection>
         <developerConnection>scm:git:git@github.com:IBM/ibmcloud-cfenv-processors.git</developerConnection>
         <url>https://github.com/IBM/ibmcloud-cfenv-processors</url>
-      <tag>HEAD</tag>
+      <tag>cfenv-processor-parent-0.0.13</tag>
   </scm>
 
 </project>

--- a/processors/amqp-cfenv-processor/pom.xml
+++ b/processors/amqp-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>
@@ -37,12 +37,12 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>ssl-context-spring-boot-starter</artifactId>
-            <version>0.0.13</version>
+            <version>0.0.14-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>bean-customizer-spring-boot</artifactId>
-            <version>0.0.13</version>
+            <version>0.0.14-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.amqp</groupId>

--- a/processors/amqp-cfenv-processor/pom.xml
+++ b/processors/amqp-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>
@@ -37,12 +37,12 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>ssl-context-spring-boot-starter</artifactId>
-            <version>0.0.14-SNAPSHOT</version>
+            <version>0.0.14</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>bean-customizer-spring-boot</artifactId>
-            <version>0.0.14-SNAPSHOT</version>
+            <version>0.0.14</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.amqp</groupId>

--- a/processors/amqp-cfenv-processor/pom.xml
+++ b/processors/amqp-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>
@@ -37,12 +37,12 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>ssl-context-spring-boot-starter</artifactId>
-            <version>0.0.13-SNAPSHOT</version>
+            <version>0.0.13</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>bean-customizer-spring-boot</artifactId>
-            <version>0.0.13-SNAPSHOT</version>
+            <version>0.0.13</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.amqp</groupId>

--- a/processors/amqp-cfenv-processor/pom.xml
+++ b/processors/amqp-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>
@@ -37,12 +37,12 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>ssl-context-spring-boot-starter</artifactId>
-            <version>0.0.14</version>
+            <version>0.0.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>bean-customizer-spring-boot</artifactId>
-            <version>0.0.14</version>
+            <version>0.0.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.amqp</groupId>

--- a/processors/amqp-cfenv-processor/src/main/java/com/ibm/cfenv/spring/boot/amqp/AmqpSSLContextBeanCustomizer.java
+++ b/processors/amqp-cfenv-processor/src/main/java/com/ibm/cfenv/spring/boot/amqp/AmqpSSLContextBeanCustomizer.java
@@ -40,6 +40,8 @@ public class AmqpSSLContextBeanCustomizer implements BeanCustomizer<CachingConne
             connectionFactory.useSslProtocol(sslContext);
             Method enableHostnameVerification = null;
             try {
+                // check if enableHostnameVerification method exists in ConnectionFactory and invoke using Java Reflection API.
+                // spring-rabbit version pulled by Spring boot 1.5.x doesn't support enableHostnameVerification method. 
                 enableHostnameVerification = ConnectionFactory.class.getMethod("enableHostnameVerification");
                 enableHostnameVerification.invoke(connectionFactory);
             } catch (NoSuchMethodException e) {

--- a/processors/appid-cfenv-processor/pom.xml
+++ b/processors/appid-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>

--- a/processors/appid-cfenv-processor/pom.xml
+++ b/processors/appid-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>

--- a/processors/appid-cfenv-processor/pom.xml
+++ b/processors/appid-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>

--- a/processors/appid-cfenv-processor/pom.xml
+++ b/processors/appid-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>

--- a/processors/cloudant-cfenv-processor/pom.xml
+++ b/processors/cloudant-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/cloudant-cfenv-processor/pom.xml
+++ b/processors/cloudant-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/cloudant-cfenv-processor/pom.xml
+++ b/processors/cloudant-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/cloudant-cfenv-processor/pom.xml
+++ b/processors/cloudant-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/db2-cfenv-processor/pom.xml
+++ b/processors/db2-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/db2-cfenv-processor/pom.xml
+++ b/processors/db2-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/db2-cfenv-processor/pom.xml
+++ b/processors/db2-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/db2-cfenv-processor/pom.xml
+++ b/processors/db2-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/event-streams-cfenv-processor/pom.xml
+++ b/processors/event-streams-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/event-streams-cfenv-processor/pom.xml
+++ b/processors/event-streams-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/event-streams-cfenv-processor/pom.xml
+++ b/processors/event-streams-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/event-streams-cfenv-processor/pom.xml
+++ b/processors/event-streams-cfenv-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cfenv-processors</artifactId>
         <groupId>com.ibm.cloud</groupId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/processors/mongodb-cfenv-processor/pom.xml
+++ b/processors/mongodb-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>ssl-context-spring-boot-starter</artifactId>
-            <version>0.0.14</version>
+            <version>0.0.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>bean-customizer-spring-boot</artifactId>
-            <version>0.0.14</version>
+            <version>0.0.15-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/processors/mongodb-cfenv-processor/pom.xml
+++ b/processors/mongodb-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>ssl-context-spring-boot-starter</artifactId>
-            <version>0.0.13-SNAPSHOT</version>
+            <version>0.0.13</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>bean-customizer-spring-boot</artifactId>
-            <version>0.0.13-SNAPSHOT</version>
+            <version>0.0.13</version>
         </dependency>
 
         <dependency>

--- a/processors/mongodb-cfenv-processor/pom.xml
+++ b/processors/mongodb-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>ssl-context-spring-boot-starter</artifactId>
-            <version>0.0.13</version>
+            <version>0.0.14-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>bean-customizer-spring-boot</artifactId>
-            <version>0.0.13</version>
+            <version>0.0.14-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/processors/mongodb-cfenv-processor/pom.xml
+++ b/processors/mongodb-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
 
     <groupId>com.ibm.cfenv</groupId>
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>ssl-context-spring-boot-starter</artifactId>
-            <version>0.0.14-SNAPSHOT</version>
+            <version>0.0.14</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>bean-customizer-spring-boot</artifactId>
-            <version>0.0.14-SNAPSHOT</version>
+            <version>0.0.14</version>
         </dependency>
 
         <dependency>

--- a/processors/pom.xml
+++ b/processors/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/processors/pom.xml
+++ b/processors/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/processors/pom.xml
+++ b/processors/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/processors/pom.xml
+++ b/processors/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/processors/watson-cfenv-processor/pom.xml
+++ b/processors/watson-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
 
     <artifactId>watson-cfenv-processor</artifactId>

--- a/processors/watson-cfenv-processor/pom.xml
+++ b/processors/watson-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
 
     <artifactId>watson-cfenv-processor</artifactId>

--- a/processors/watson-cfenv-processor/pom.xml
+++ b/processors/watson-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
 
     <artifactId>watson-cfenv-processor</artifactId>

--- a/processors/watson-cfenv-processor/pom.xml
+++ b/processors/watson-cfenv-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processors</artifactId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
 
     <artifactId>watson-cfenv-processor</artifactId>

--- a/samples/amqp-mongo-kafka/pom.xml
+++ b/samples/amqp-mongo-kafka/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>samples</artifactId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>
     <artifactId>amqp-mongo-kafka</artifactId>
     <description>Demo project for Spring Boot</description>
-    <version>0.0.13-SNAPSHOT</version>
+    <version>0.0.13</version>
 
     <properties>
         <java.version>1.8</java.version>
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>amqp-cfenv-processor</artifactId>
-            <version>0.0.13-SNAPSHOT</version>
+            <version>0.0.13</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>mongodb-cfenv-processor</artifactId>
-            <version>0.0.13-SNAPSHOT</version>
+            <version>0.0.13</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>event-streams-cfenv-processor</artifactId>
-            <version>0.0.13-SNAPSHOT</version>
+            <version>0.0.13</version>
         </dependency>
 
         <dependency>

--- a/samples/amqp-mongo-kafka/pom.xml
+++ b/samples/amqp-mongo-kafka/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>samples</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>
     <artifactId>amqp-mongo-kafka</artifactId>
     <description>Demo project for Spring Boot</description>
-    <version>0.0.14</version>
+    <version>0.0.15-SNAPSHOT</version>
 
     <properties>
         <java.version>1.8</java.version>
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>amqp-cfenv-processor</artifactId>
-            <version>0.0.14</version>
+            <version>0.0.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>mongodb-cfenv-processor</artifactId>
-            <version>0.0.14</version>
+            <version>0.0.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>event-streams-cfenv-processor</artifactId>
-            <version>0.0.14</version>
+            <version>0.0.15-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/samples/amqp-mongo-kafka/pom.xml
+++ b/samples/amqp-mongo-kafka/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>samples</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>
     <artifactId>amqp-mongo-kafka</artifactId>
     <description>Demo project for Spring Boot</description>
-    <version>0.0.13</version>
+    <version>0.0.14-SNAPSHOT</version>
 
     <properties>
         <java.version>1.8</java.version>
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>amqp-cfenv-processor</artifactId>
-            <version>0.0.13</version>
+            <version>0.0.14-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>mongodb-cfenv-processor</artifactId>
-            <version>0.0.13</version>
+            <version>0.0.14-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>event-streams-cfenv-processor</artifactId>
-            <version>0.0.13</version>
+            <version>0.0.14-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/samples/amqp-mongo-kafka/pom.xml
+++ b/samples/amqp-mongo-kafka/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>samples</artifactId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>
     <artifactId>amqp-mongo-kafka</artifactId>
     <description>Demo project for Spring Boot</description>
-    <version>0.0.14-SNAPSHOT</version>
+    <version>0.0.14</version>
 
     <properties>
         <java.version>1.8</java.version>
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>amqp-cfenv-processor</artifactId>
-            <version>0.0.14-SNAPSHOT</version>
+            <version>0.0.14</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>mongodb-cfenv-processor</artifactId>
-            <version>0.0.14-SNAPSHOT</version>
+            <version>0.0.14</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cfenv</groupId>
             <artifactId>event-streams-cfenv-processor</artifactId>
-            <version>0.0.14-SNAPSHOT</version>
+            <version>0.0.14</version>
         </dependency>
 
         <dependency>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/starters/bean-customizer-spring-boot/pom.xml
+++ b/starters/bean-customizer-spring-boot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>starters</artifactId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
 
     <artifactId>bean-customizer-spring-boot</artifactId>

--- a/starters/bean-customizer-spring-boot/pom.xml
+++ b/starters/bean-customizer-spring-boot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>starters</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
 
     <artifactId>bean-customizer-spring-boot</artifactId>

--- a/starters/bean-customizer-spring-boot/pom.xml
+++ b/starters/bean-customizer-spring-boot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>starters</artifactId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
 
     <artifactId>bean-customizer-spring-boot</artifactId>

--- a/starters/bean-customizer-spring-boot/pom.xml
+++ b/starters/bean-customizer-spring-boot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>starters</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
 
     <artifactId>bean-customizer-spring-boot</artifactId>

--- a/starters/bean-customizer-spring-boot/src/main/java/com/ibm/beancustomizer/config/TypedBeanPostProcessor.java
+++ b/starters/bean-customizer-spring-boot/src/main/java/com/ibm/beancustomizer/config/TypedBeanPostProcessor.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Simple attempt to avoid having every bean post processor processe every bean.
+ * Simple attempt to avoid having every bean post processor processes every bean.
  * Instead, this one will only process beans it knows it has BeanCustomizers for.
  */
 class TypedBeanPostProcessor implements BeanPostProcessor {
@@ -31,7 +31,11 @@ class TypedBeanPostProcessor implements BeanPostProcessor {
         if (beanCustomizers.isEmpty()) {
             return bean;
         } else if (beanCustomizers.size() == 1) {
-            return beanCustomizers.get(0).postProcessAfterInit(bean);
+            try {
+                return beanCustomizers.get(0).postProcessAfterInit(bean);
+            } catch (Exception e) {
+                 throw new BeanCreationException("Error post processing bean", e);
+            }
         } else {
             throw new BeanCreationException("Multiple bean customizers found");
         }
@@ -45,7 +49,11 @@ class TypedBeanPostProcessor implements BeanPostProcessor {
         if (beanCustomizers.isEmpty()) {
             return bean;
         } else if (beanCustomizers.size() == 1) {
-            return beanCustomizers.get(0).postProcessBeforeInit(bean);
+            try {
+                return beanCustomizers.get(0).postProcessBeforeInit(bean);
+            } catch (Exception e) {
+                throw new BeanCreationException("Error post processing bean", e);
+            }
         } else {
             throw new BeanCreationException("Multiple bean customizers found");
         }

--- a/starters/pom.xml
+++ b/starters/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/starters/pom.xml
+++ b/starters/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/starters/pom.xml
+++ b/starters/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/starters/pom.xml
+++ b/starters/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>cfenv-processor-parent</artifactId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
 
     <groupId>com.ibm.cloud</groupId>

--- a/starters/ssl-context-spring-boot-starter/pom.xml
+++ b/starters/ssl-context-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>starters</artifactId>
-        <version>0.0.14-SNAPSHOT</version>
+        <version>0.0.14</version>
     </parent>
 
     <name>ssl-context-spring-boot-starter</name>

--- a/starters/ssl-context-spring-boot-starter/pom.xml
+++ b/starters/ssl-context-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>starters</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15-SNAPSHOT</version>
     </parent>
 
     <name>ssl-context-spring-boot-starter</name>

--- a/starters/ssl-context-spring-boot-starter/pom.xml
+++ b/starters/ssl-context-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>starters</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14-SNAPSHOT</version>
     </parent>
 
     <name>ssl-context-spring-boot-starter</name>

--- a/starters/ssl-context-spring-boot-starter/pom.xml
+++ b/starters/ssl-context-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.cloud</groupId>
         <artifactId>starters</artifactId>
-        <version>0.0.13-SNAPSHOT</version>
+        <version>0.0.13</version>
     </parent>
 
     <name>ssl-context-spring-boot-starter</name>


### PR DESCRIPTION
This PR fixes the AMQP Cfenv processor not working in 1.5.x spring boot version which brings `spring-rabbit` 1.7.3.RELEASE version by checking if the method enableHostnameVerification exists or not in com.rabbitmq.client.ConnectionFactory and invoke if present.